### PR TITLE
Remove unused Text namespace

### DIFF
--- a/Assets/Scripts/Managers/TurnManager.cs
+++ b/Assets/Scripts/Managers/TurnManager.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
-using UnityEngine.TextCore.Text;
 
 public class TurnManager : MonoBehaviour
 {


### PR DESCRIPTION
## Summary
- clean up `TurnManager.cs` by removing unused `UnityEngine.TextCore.Text` namespace

## Testing
- `mcs Assets/Scripts/Managers/TurnManager.cs -out:/tmp/TurnManager.dll` *(fails: `UnityEngine` reference missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ac1114d34833195f3ff9ccaea647c